### PR TITLE
Updating deprecated functions in HA

### DIFF
--- a/custom_components/beward/__init__.py
+++ b/custom_components/beward/__init__.py
@@ -142,9 +142,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Load platforms
     for platform in PLATFORMS:
-        hass.async_add_job(
-            hass.config_entries.async_forward_entry_setup(entry, platform)
-        )
+        await hass.config_entries.async_forward_entry_setups(entry, [platform])
 
     return len(hass.data[DOMAIN]) > 0
 

--- a/custom_components/beward/camera.py
+++ b/custom_components/beward/camera.py
@@ -20,7 +20,7 @@ import async_timeout
 import beward
 from haffmpeg.camera import CameraMjpeg
 
-from homeassistant.components.camera import SUPPORT_STREAM, Camera as CameraEntity
+from homeassistant.components.camera import CameraEntityFeature, Camera as CameraEntity
 from homeassistant.components.ffmpeg import DATA_FFMPEG, FFmpegManager
 from homeassistant.components.local_file.camera import LocalFile
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
@@ -125,7 +125,7 @@ class BewardLiveCamera(BewardEntity, CameraEntity):
     def supported_features(self) -> Optional[int]:
         """Return supported features."""
         if self._stream_url:
-            return SUPPORT_STREAM
+            return CameraEntityFeature.STREAM
         return 0
 
     def camera_image(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixing issue: https://github.com/Limych/ha-beward/issues/72 
Updating deprecation calls to new functions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an this integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Fixing the following issues printed by HA:
  - WARNING (MainThread) [homeassistant.helpers.frame] Detected code that calls async_forward_entry_setup for integration, beward with title: configuration.yaml and entry_id: ***, which is deprecated and will stop working in Home Assistant 2025.6, await async_forward_entry_setups instead. Please report this issue.

  - WARNING (ImportExecutor_0) [homeassistant.components.camera] SUPPORT_STREAM was used from beward, this is a deprecated constant which will be removed in HA Core 2025.1. Use CameraEntityFeature.STREAM instead, please report it to the author of the 'beward' custom integration.


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] The code has been formatted using Black (`black --fast custom_components`)

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated to README.md

<!--
  Thank you for contributing <3
-->
